### PR TITLE
update intl version to 0.17.0

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,7 +10,7 @@ dependencies:
   flutter:
     sdk: flutter
   scrollable_positioned_list: ^0.1.8
-  intl: ^0.16.1
+  intl: ^0.17.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
[issue](https://github.com/ikicodedev/calendar_timeline/issues/22)

If the flutter version has been updated and the intl 0.17.0 version that supports null-safety is used, a version conflict occurs when the calendar-timeline package is included. 