### PR TITLE
variable 'shrink' to save more space

### DIFF
--- a/lib/src/calendar_timeline.dart
+++ b/lib/src/calendar_timeline.dart
@@ -27,6 +27,7 @@ class CalendarTimeline extends StatefulWidget {
   final Color? monthColor;
   final Color? dotsColor;
   final Color? dayNameColor;
+  final bool shrink;
   final String? locale;
 
   /// If true, it will show a separate row for the years.
@@ -47,6 +48,7 @@ class CalendarTimeline extends StatefulWidget {
     this.monthColor,
     this.dotsColor,
     this.dayNameColor,
+    this.shrink = false,
     this.locale,
     this.showYears = false,
   })  : assert(
@@ -337,6 +339,7 @@ class _CalendarTimelineState extends State<CalendarTimeline> {
                   onTap: () => _onSelectYear(index),
                   color: widget.monthColor,
                   small: false,
+                  shrink: widget.shrink,
                 ),
                 if (index == _years.length - 1)
                   // Last element to take space to do scroll to left side
@@ -358,7 +361,7 @@ class _CalendarTimelineState extends State<CalendarTimeline> {
   /// months in the calendar and the small version of [YearItem] for each year in between
   Widget _buildMonthList() {
     return Container(
-      height: 40,
+      height: 30,
       child: ScrollablePositionedList.builder(
         initialScrollIndex: _monthSelectedIndex ?? 0,
         initialAlignment: _scrollAlignment,
@@ -386,6 +389,7 @@ class _CalendarTimelineState extends State<CalendarTimeline> {
                       name: DateFormat.y(_locale).format(currentDate),
                       color: widget.monthColor,
                       onTap: () {},
+                      shrink: widget.shrink,
                     ),
                   ),
                 MonthItem(
@@ -393,6 +397,7 @@ class _CalendarTimelineState extends State<CalendarTimeline> {
                   name: monthName,
                   onTap: () => _onSelectMonth(index),
                   color: widget.monthColor,
+                  shrink: widget.shrink,
                 ),
                 if (index == _months.length - 1)
                   // Last element to take space to do scroll to left side
@@ -415,14 +420,14 @@ class _CalendarTimelineState extends State<CalendarTimeline> {
   Widget _buildDayList() {
     return SizedBox(
       key: Key('ScrollableDayList'),
-      height: 75,
+      height: 40,
       child: ScrollablePositionedList.builder(
         itemScrollController: _controllerDay,
         initialScrollIndex: _daySelectedIndex ?? 0,
         initialAlignment: _scrollAlignment,
         scrollDirection: Axis.horizontal,
         itemCount: _days.length,
-        padding: EdgeInsets.only(left: widget.leftMargin, right: 10),
+        padding: EdgeInsets.only(left: widget.leftMargin, right: 6),
         itemBuilder: (BuildContext context, int index) {
           final currentDay = _days[index];
           final shortName =
@@ -444,6 +449,7 @@ class _CalendarTimelineState extends State<CalendarTimeline> {
                 activeDayBackgroundColor: widget.activeBackgroundDayColor,
                 dotsColor: widget.dotsColor,
                 dayNameColor: widget.dayNameColor,
+                shrink: widget.shrink,
               ),
               if (index == _days.length - 1)
                 // Last element to take space to do scroll to left side

--- a/lib/src/calendar_timeline.dart
+++ b/lib/src/calendar_timeline.dart
@@ -398,6 +398,7 @@ class _CalendarTimelineState extends State<CalendarTimeline> {
                   onTap: () => _onSelectMonth(index),
                   color: widget.monthColor,
                   shrink: widget.shrink,
+                  activeColor: widget.activeBackgroundDayColor,
                 ),
                 if (index == _months.length - 1)
                   // Last element to take space to do scroll to left side

--- a/lib/src/day_item.dart
+++ b/lib/src/day_item.dart
@@ -12,8 +12,9 @@ class DayItem extends StatelessWidget {
   final bool available;
   final Color? dotsColor;
   final Color? dayNameColor;
+  final bool shrink;
 
-  const DayItem({
+  DayItem({
     Key? key,
     required this.dayNumber,
     required this.shortName,
@@ -25,10 +26,9 @@ class DayItem extends StatelessWidget {
     this.available = true,
     this.dotsColor,
     this.dayNameColor,
+    this.shrink = false,
   }) : super(key: key);
 
-  final double height = 70.0;
-  final double width = 60.0;
 
   _buildDay(BuildContext context) {
     final textStyle = TextStyle(
@@ -36,11 +36,11 @@ class DayItem extends StatelessWidget {
         ? dayColor ?? Theme.of(context).colorScheme.secondary
         : dayColor?.withOpacity(0.5) ??
         Theme.of(context).colorScheme.secondary.withOpacity(0.5),
-      fontSize: 32,
+      fontSize: shrink ? 14 : 32,
       fontWeight: FontWeight.normal);
     final selectedStyle = TextStyle(
       color: activeDayColor ?? Colors.white,
-      fontSize: 32,
+      fontSize: shrink ? 14 : 32,
       fontWeight: FontWeight.bold,
       height: 0.8,
     );
@@ -55,16 +55,16 @@ class DayItem extends StatelessWidget {
           borderRadius: BorderRadius.circular(12.0),
         )
           : BoxDecoration(color: Colors.transparent),
-        height: height,
-        width: width,
+        height: shrink ? 40 : 70,
+        width: shrink ? 33 : 60,
         child: Column(
           children: <Widget>[
             if (isSelected) ...[
-              SizedBox(height: 7),
-              _buildDots(),
-              SizedBox(height: 12),
+              SizedBox(height: shrink ? 6 : 7),
+              if(! shrink) _buildDots(),
+              SizedBox(height: shrink ? 9 : 12),
             ] else
-              SizedBox(height: 14),
+              SizedBox(height:shrink ? 10 : 14),
             Text(
               dayNumber.toString(),
               style: isSelected ? selectedStyle : textStyle,
@@ -75,7 +75,7 @@ class DayItem extends StatelessWidget {
                 style: TextStyle(
                   color: dayNameColor ?? activeDayColor ?? Colors.white,
                   fontWeight: FontWeight.bold,
-                  fontSize: 14,
+                  fontSize: shrink ? 9 :  14,
                 ),
               ),
           ],

--- a/lib/src/month_item.dart
+++ b/lib/src/month_item.dart
@@ -6,12 +6,14 @@ class MonthItem extends StatelessWidget {
   final Function onTap;
   final bool isSelected;
   final Color? color;
+  final bool shrink;
 
   MonthItem({
     required this.name,
     required this.onTap,
     this.isSelected = false,
-    this.color
+    this.color,
+    required this.shrink
   });
 
   @override
@@ -21,7 +23,7 @@ class MonthItem extends StatelessWidget {
       child: Text(
         this.name.toUpperCase(),
         style: TextStyle(
-          fontSize: 14,
+          fontSize: shrink ? 10 : 14,
           color: color ?? Colors.black87,
           fontWeight: this.isSelected ? FontWeight.bold : FontWeight.w300,
         ),

--- a/lib/src/month_item.dart
+++ b/lib/src/month_item.dart
@@ -6,6 +6,7 @@ class MonthItem extends StatelessWidget {
   final Function onTap;
   final bool isSelected;
   final Color? color;
+  final Color? activeColor;
   final bool shrink;
 
   MonthItem({
@@ -13,6 +14,7 @@ class MonthItem extends StatelessWidget {
     required this.onTap,
     this.isSelected = false,
     this.color,
+    this.activeColor,
     required this.shrink
   });
 
@@ -24,8 +26,8 @@ class MonthItem extends StatelessWidget {
         this.name.toUpperCase(),
         style: TextStyle(
           fontSize: shrink ? 10 : 14,
-          color: color ?? Colors.black87,
-          fontWeight: this.isSelected ? FontWeight.bold : FontWeight.w300,
+          color: this.isSelected ? activeColor ?? Color(0xFF002265) : color ?? Colors.black87,
+          fontWeight: this.isSelected ? FontWeight.bold : FontWeight.normal,
         ),
       ),
     );

--- a/lib/src/year_item.dart
+++ b/lib/src/year_item.dart
@@ -9,13 +9,16 @@ class YearItem extends StatelessWidget {
   final bool isSelected;
   final Color? color;
   final bool small;
+  final bool shrink;
+
 
   YearItem({
     required this.name,
     required this.onTap,
     this.isSelected = false,
     this.small = true,
-    this.color
+    this.color,
+    required this.shrink,
   });
 
   @override
@@ -34,7 +37,7 @@ class YearItem extends StatelessWidget {
           child: Text(
             name.toUpperCase(),
             style: TextStyle(
-              fontSize: small ? 12 : 20,
+              fontSize: shrink ? 9 : small ? 12 : 20,
               color: color ?? Colors.black87,
               fontWeight: FontWeight.bold,
             ),


### PR DESCRIPTION
current font sizes take more screen space, and does not sync with other form fields. so shrink variable will remove dots and reduce paddings.

active month is not distinguishable, so i put active day background color to active month