### PR TITLE
added showDayShortNames option for the day item

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.1.4 - 25/07/2024
+
+* Added `showDayShortNames` parameter, to determine if day names should also show for not selected dates
+* Changed order in which `activeDayColor`, `dayNameColor` are applied to day short text, `activeDayColor` now has priority
+
 ## 1.1.3 - 14/03/2023
 
 * Minor updates, Flutter packages update

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -23,7 +23,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "1.1.2"
+    version: "1.1.3"
   characters:
     dependency: transitive
     description:

--- a/lib/src/calendar_timeline.dart
+++ b/lib/src/calendar_timeline.dart
@@ -39,6 +39,7 @@ class CalendarTimeline extends StatefulWidget {
     this.shrink = false,
     this.locale,
     this.showYears = false,
+    this.showDayShortNames = false,
     this.eventDates,
   })  : assert(
           initialDate.difference(firstDate).inDays >= 0,
@@ -84,6 +85,7 @@ class CalendarTimeline extends StatefulWidget {
   final bool shrink;
   final String? locale;
   final List<DateTime>? eventDates;
+  final bool showDayShortNames;
 
   /// If true, it will show a separate row for the years.
   /// It defaults to false
@@ -496,6 +498,7 @@ class _CalendarTimelineState extends State<CalendarTimeline> {
                 dayNameFontSize: widget.dayNameFontSize,
                 shrinkDayNameFontSize: widget.shrinkDayNameFontSize,
                 shrink: widget.shrink,
+                showDayName: widget.showDayShortNames,
               ),
               if (index == _days.length - 1)
                 // Last element to take space to do scroll to left side

--- a/lib/src/day_item.dart
+++ b/lib/src/day_item.dart
@@ -13,6 +13,7 @@ class DayItem extends StatelessWidget {
     this.activeDayBackgroundColor,
     this.available = true,
     this.showDot = false,
+    this.showDayName = false,
     this.dotColor,
     this.dayNameColor,
     required this.height,
@@ -45,6 +46,7 @@ class DayItem extends StatelessWidget {
   final double dayNameFontSize;
   final double shrinkDayNameFontSize;
   final bool shrink;
+  final bool showDayName;
 
   GestureDetector _buildDay(BuildContext context) {
     final textStyle = TextStyle(
@@ -61,6 +63,12 @@ class DayItem extends StatelessWidget {
       fontWeight: FontWeight.bold,
       height: 0.8,
     );
+
+    final dayTextColor = isSelected
+        ? activeDayColor ?? dayNameColor ?? Colors.white
+        : showDayName
+            ? dayNameColor
+            : Colors.transparent;
 
     return GestureDetector(
       onTap: available ? onTap as void Function()? : null,
@@ -98,9 +106,7 @@ class DayItem extends StatelessWidget {
               child: Text(
                 shortName,
                 style: TextStyle(
-                  color: isSelected
-                      ? dayNameColor ?? activeDayColor ?? Colors.white
-                      : Colors.transparent,
+                  color: dayTextColor,
                   fontWeight: FontWeight.bold,
                   fontSize: shrink ? shrinkDayNameFontSize : dayNameFontSize,
                 ),

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: calendar_timeline
 description: A horizontal date picker that takes up little screen space, so we
   can always have it visible, and that facilitates use with one hand.
-version: 1.1.3
+version: 1.1.4
 homepage: https://github.com/muhammadtalhasultan/calendar_timeline
 
 environment:


### PR DESCRIPTION
Hello, 
my team and I have a use case in which we want to show the day names for all items. For this purpose, I've introduced a new param to `CalendarTimeline` widget. This is done in a way that does not break existing functionality and only provides further customization options. 

Please review and release it ASAP. 
